### PR TITLE
Merge accel/gyro rows with co2 data

### DIFF
--- a/data-processing.ipynb
+++ b/data-processing.ipynb
@@ -24,15 +24,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "598ee2cc",
    "metadata": {},
    "outputs": [],
    "source": [
     "#Import trial data\n",
     "file_path = r\"C:\\Users\\jgx7497\\Documents\\BME 390-3\\Jay_Quarter2_Trial(in).csv\"\n",
-    "trial_df = pd.read_csv(file_path)\n"
+    "df = pd.read_csv(file_path)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "6da2ba1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the CSV into a DataFrame.\n",
+    "df = pd.read_csv(file_path)\n",
+    "    \n",
+    "# Define the required columns.\n",
+    "required_cols = ['Time(ms)', 'Acc_x(g)', 'Acc_y(g)', 'Acc_z(g)',\n",
+    "                 'Gyro_x', 'Gyro_y', 'Gyro_z', 'CO2(ppm)']\n",
+    "missing_cols = [col for col in required_cols if col not in df.columns]\n",
+    "if missing_cols:\n",
+    "    raise ValueError(\"Missing required columns: \" + \", \".join(missing_cols))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "a97bae1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Identify the accel/gyro rows and CO2 rows respectively\n",
+    "co2_rows = df[df['CO2(ppm)'] != 0].copy()\n",
+    "sensor_rows = df[(df[['Acc_x(g)', 'Acc_y(g)', 'Acc_z(g)', 'Gyro_x', 'Gyro_y', 'Gyro_z']] != 0).any(axis=1)].copy()\n",
+    "#Define tolerance in ms\n",
+    "tolerance = 5\n",
+    "merged_rows = []\n",
+    "\n",
+    "#Prepare an empty list to collecte the merged rows\n",
+    "for idx, co2_row in co2_rows.iterrows():\n",
+    "    #Find sensor rows within +/- 3 ms\n",
+    "    mask = (sensor_rows[\"Time(ms)\"] >= co2_row[\"Time(ms)\"] - tolerance) & (sensor_rows['Time(ms)'] <= co2_row['Time(ms)'] + tolerance)\n",
+    "    nearby_sensors = sensor_rows[mask]\n",
+    "\n",
+    "    if not nearby_sensors.empty:\n",
+    "        best_sensor = nearby_sensors.iloc[(nearby_sensors['Time(ms)'] - co2_row['Time(ms)']).abs().argsort()].iloc[0]\n",
+    "        # Merge the two rows into one\n",
+    "    merged_row = {\n",
+    "        'Time(ms)': co2_row['Time(ms)'],\n",
+    "        'Acc_x(g)': best_sensor['Acc_x(g)'],\n",
+    "        'Acc_y(g)': best_sensor['Acc_y(g)'],\n",
+    "        'Acc_z(g)': best_sensor['Acc_z(g)'],\n",
+    "        'Gyro_x': best_sensor['Gyro_x'],\n",
+    "        'Gyro_y': best_sensor['Gyro_y'],\n",
+    "        'Gyro_z': best_sensor['Gyro_z'],\n",
+    "        'CO2(ppm)': co2_row['CO2(ppm)']\n",
+    "    }\n",
+    "    merged_rows.append(merged_row)\n",
+    "\n",
+    "merged_df = pd.DataFrame(merged_rows)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9054228",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Added code that will look at the CSV file and check the timestamps at which CO2 and acceleration data was recorded. If this difference in collection time is <3 ms (tolerance variable), merge the co2 data with the accleration data. Throw out any other excess rows of accel data